### PR TITLE
Some oauth client API tweaks

### DIFF
--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -60,9 +60,6 @@ def scope_matches(provided, required):
     :param required: the scope required (e.g. by the application).
     :returns: ``True`` if all required scopes are provided, ``False`` if not.
     """
-    if not required:
-        return True
-
     if not isinstance(required, (list, tuple)):
         required = [required]
 

--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -53,12 +53,12 @@ def scope_matches(provided, required):
 
         Sub-scopes are expressed using semi-colons.
 
-        A required sub-scope will always match if its root-scope is among
-        provided (e.g. ``profile:avatar`` will match ``profile`` is provided).
+        A required sub-scope will always match if its root-scope is among those
+        provided (e.g. ``profile:avatar`` will match ``profile`` if provided).
 
     :param provided: list of scopes provided for the current token.
     :param required: the scope required (e.g. by the application).
-    :returns: ``True`` if matches ``False`` otherwise.
+    :returns: ``True`` if all required scopes are provided, ``False`` if not.
     """
     if not required:
         return True

--- a/fxa/errors.py
+++ b/fxa/errors.py
@@ -51,9 +51,18 @@ class ServerError(InProtocolError):
     pass
 
 
-class ScopeMismatchError(InProtocolError):
+class TrustError(Error):
+    """Base error class for security conditions being violated.
+
+    Examples might include a bad signature on some data, a mismatched
+    audience on an assertion, or a missing scope on an OAuth token.
+    """
+    pass
+
+
+class ScopeMismatchError(TrustError):
     """Error raised when the OAuth scopes do not match."""
+
     def __init__(self, provided, required):
-        message = "{0} does not match {1}".format(provided, required)
-        details = dict(message=message)
-        super(ScopeMismatchError, self).__init__(details)
+        message = "scope {0} does not match {1}".format(provided, required)
+        super(ScopeMismatchError, self).__init__(message)

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -12,7 +12,7 @@ DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com"
 
 
 class Client(object):
-    """Client for talking to the Firefox OAuth server"""
+    """Client for talking to the Firefox Accounts OAuth server"""
 
     def __init__(self, server_url=None):
         if server_url is None:
@@ -44,12 +44,13 @@ class Client(object):
         return resp['access_token']
 
     def verify_token(self, token, scope=None):
-        """Verify a OAuth token, and retrieve user id and scopes.
+        """Verify an OAuth token, and retrieve user id and scopes.
 
         :param token: the string to verify.
         :param scope: optional scope expected to be provided for this token.
         :returns: a dict with user id and authorized scopes for this token.
         :raises fxa.errors.ClientError: if the provided token is invalid.
+        :raises fxa.errors.TrustError: if the token scopes do not match.
         """
         url = '/v1/verify'
         body = {

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -64,8 +64,9 @@ class Client(object):
             error_msg = '{0} missing in OAuth response'.format(missing_attrs)
             raise OutOfProtocolError(error_msg)
 
-        authorized_scope = resp['scope']
-        if not scope_matches(authorized_scope, scope):
-            raise ScopeMismatchError(authorized_scope, scope)
+        if scope is not None:
+            authorized_scope = resp['scope']
+            if not scope_matches(authorized_scope, scope):
+                raise ScopeMismatchError(authorized_scope, scope)
 
         return resp

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -14,7 +14,9 @@ DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com"
 class Client(object):
     """Client for talking to the Firefox Accounts OAuth server"""
 
-    def __init__(self, server_url=None):
+    def __init__(self, client_id=None, client_secret=None, server_url=None):
+        self.client_id = client_id
+        self.client_secret = client_secret
         if server_url is None:
             server_url = DEFAULT_SERVER_URL
         if isinstance(server_url, string_types):
@@ -22,13 +24,18 @@ class Client(object):
         else:
             self.apiclient = server_url
 
-    def trade_code(self, client_id, client_secret, code):
+    def trade_code(self, code, client_id=None, client_secret=None):
         """Trade the authentication code for a longer lived token.
 
+        :param code: the authentication code from the oauth redirect dance.
         :param client_id: the string generated during FxA client registration.
         :param client_secret: the related secret string.
         :returns: a dict with user id and authorized scopes for this token.
         """
+        if client_id is None:
+            client_id = self.client_id
+        if client_secret is None:
+            client_secret = self.client_secret
         url = '/v1/token'
         body = {
             'code': code,

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -60,6 +60,23 @@ class TestClientTradeCode(unittest.TestCase):
                           client_secret='cake',
                           code='1234')
 
+    @responses.activate
+    def test_trade_token_can_take_client_credentials_as_arguments(self):
+        responses.add(responses.POST,
+                      'https://server/v1/token',
+                      body='{"access_token": "tokay"}',
+                      content_type='application/json')
+        # As positional arguments.
+        token = self.client.trade_code('1234', 'abc', 'cake')
+        self.assertEqual(token, "tokay")
+        # As keyword arguments.
+        token = self.client.trade_code(
+            code='1234',
+            client_id='abc',
+            client_secret='cake'
+        )
+        self.assertEqual(token, "tokay")
+
 
 class TestAuthClientVerifyCode(unittest.TestCase):
 

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
 import json
 
 import responses
 
 import fxa.errors
 from fxa.oauth import Client, scope_matches
+
+from fxa.tests.utils import unittest
 
 
 TEST_SERVER_URL = "https://server"
@@ -124,8 +125,11 @@ class TestAuthClientVerifyCode(unittest.TestCase):
 class TestScopeMatch(unittest.TestCase):
     def test_always_matches_if_required_is_empty(self):
         self.assertTrue(scope_matches(['abc'], []))
-        self.assertTrue(scope_matches(['abc'], None))
-        self.assertTrue(scope_matches(['abc'], ''))
+
+    def test_do_not_match_if_invalid_scope_provided(self):
+        self.assertFalse(scope_matches(['abc'], ''))
+        with self.assertRaises(Exception):
+            scope_matches(['abc'], None)
 
     def test_do_not_match_if_root_scopes_are_different(self):
         self.assertFalse(scope_matches(['abc'], 'def'))

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -21,7 +21,7 @@ class TestClientTradeCode(unittest.TestCase):
 
     @responses.activate
     def setUp(self):
-        self.client = Client(self.server_url)
+        self.client = Client('abc', 'cake', self.server_url)
 
         body = '{"access_token": "yeah"}'
         responses.add(responses.POST,
@@ -29,9 +29,7 @@ class TestClientTradeCode(unittest.TestCase):
                       body=body,
                       content_type='application/json')
 
-        self.token = self.client.trade_code(client_id='abc',
-                                            client_secret='cake',
-                                            code='1234')
+        self.token = self.client.trade_code('1234')
         self.response = responses.calls[0]
 
     def test_reaches_server_on_token_url(self):
@@ -69,7 +67,7 @@ class TestAuthClientVerifyCode(unittest.TestCase):
 
     @responses.activate
     def setUp(self):
-        self.client = Client(self.server_url)
+        self.client = Client(server_url=self.server_url)
 
         body = '{"user": "alice", "scope": ["profile"], "client_id": "abc"}'
         responses.add(responses.POST,


### PR DESCRIPTION
A couple of suggested tweaks to the oauth client API:

  * Create a new error hierarchy for scope errors, since they're not really a client *or* server error
  * Don't allow calling the low-level scope_matches function with required=None
  * Make client_id and client_secret be properties of the oauth.Client object

@leplatrem thoughts?