### PR TITLE
Add helper methods for getting assertions and oauth tokens

### DIFF
--- a/fxa/crypto.py
+++ b/fxa/crypto.py
@@ -153,4 +153,4 @@ def generate_keypair():
     }
     private_key = browserid.jwt.DS128Key(data)
     del data["x"]
-    return (data, private_key)
+    return data, private_key

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from six import string_types
+from six.moves.urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 from fxa.errors import OutOfProtocolError, ScopeMismatchError
 from fxa._utils import APIClient, scope_matches
@@ -28,6 +29,31 @@ class Client(object):
         else:
             self.apiclient = server_url
 
+    @property
+    def server_url(self):
+        return self.apiclient.server_url
+
+    def get_redirect_url(self, state="", redirect_uri=None, scope=None,
+                         action=None, email=None, client_id=None):
+        """Get the URL to redirect to to initiate the oauth flow."""
+        if client_id is None:
+            client_id = self.client_id
+        params = {
+            "client_id": client_id,
+            "state": state,
+        }
+        if redirect_uri is not None:
+            params["redirect_uri"] = redirect_uri
+        if scope is not None:
+            params["scope"] = scope
+        if action is not None:
+            params["action"] = action
+        if email is not None:
+            params["email"] = email
+        query_str = urlencode(params)
+        authorization_url = urlparse(self.server_url + "/authorization")
+        return urlunparse(authorization_url._replace(query=query_str))
+
     def trade_code(self, code, client_id=None, client_secret=None):
         """Trade the authentication code for a longer lived token.
 
@@ -46,6 +72,76 @@ class Client(object):
             'client_id': client_id,
             'client_secret': client_secret
         }
+        resp = self.apiclient.post(url, body)
+
+        if 'access_token' not in resp:
+            error_msg = 'access_token missing in OAuth response'
+            raise OutOfProtocolError(error_msg)
+
+        return resp['access_token']
+
+    def authorize_code(self, assertion, scope=None, client_id=None):
+        """Trade an identity assertion for an oauth authorization code.
+
+        This method takes an identity assertion for a user and uses it to
+        generate an oauth authentication code.  This code can in turn be
+        traded for a full-blown oauth token.
+
+        Note that the authorize_token() method does the same thing but skips
+        the intermediate step of using a short-lived code, and hence this
+        method is likely only useful for testing purposes.
+
+        :param assertion: an identity assertion for the target user.
+        :param scope: optional scope to be provided by the token.
+        :param client_id: the string generated during FxA client registration.
+        """
+        if client_id is None:
+            client_id = self.client_id
+        url = "/authorization"
+        body = {
+            "client_id": client_id,
+            "assertion": assertion,
+            "state": "x",  # state is required, but we don't use it
+        }
+        if scope is not None:
+            body["scope"] = scope
+        resp = self.apiclient.post(url, body)
+
+        if "redirect" not in resp:
+            error_msg = "redirect missing in OAuth response"
+            raise OutOfProtocolError(error_msg)
+
+        # This flow is designed for web-based redirects.
+        # In order to get the code we must parse it from the redirect url.
+        query_params = parse_qs(urlparse(resp["redirect"]).query)
+        try:
+            return query_params["code"][0]
+        except (KeyError, IndexError, ValueError):
+            error_msg = "code missing in OAuth redirect url"
+            raise OutOfProtocolError(error_msg)
+
+    def authorize_token(self, assertion, scope=None, client_id=None):
+        """Trade an identity assertion for an oauth token.
+
+        This method takes an identity assertion for a user and uses it to
+        generate an oauth token.  The client_id must have implicit grant
+        privileges.
+
+        :param assertion: an identity assertion for the target user.
+        :param scope: optional scope to be provided by the token.
+        :param client_id: the string generated during FxA client registration.
+        """
+        if client_id is None:
+            client_id = self.client_id
+        url = "/authorization"
+        body = {
+            "client_id": client_id,
+            "assertion": assertion,
+            "response_type": "token",
+            "state": "x",  # state is required, but we don't use it
+        }
+        if scope is not None:
+            body["scope"] = scope
         resp = self.apiclient.post(url, body)
 
         if 'access_token' not in resp:

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -235,3 +235,12 @@ class TestCoreClientSession(unittest.TestCase):
         # Check that encryption keys have been preserved.
         session2.fetch_keys()
         self.assertEquals(self.session.keys, session2.keys)
+
+    def test_get_identity_assertion(self):
+        assertion = self.session.get_identity_assertion("http://example.com")
+        data = browserid.verify(assertion, audience="http://example.com")
+        self.assertEquals(data["status"], "okay")
+        expected_issuer = urlparse(self.session.server_url).hostname
+        self.assertEquals(data["issuer"], expected_issuer)
+        expected_email = "{0}@{1}".format(self.session.uid, expected_issuer)
+        self.assertEquals(data["email"], expected_email)


### PR DESCRIPTION
This adds `get_identity_assertion()` to the core client class, and `authorize_code()` and `authorize_token()` methods to the oauth client class.  They're useful for simulating a full oauth flow.

@tarekziade r?

Closes #7 and #8.