### PR TITLE
Fix FxA OAuth server URLs

### DIFF
--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -8,7 +8,7 @@ from fxa.errors import OutOfProtocolError, ScopeMismatchError
 from fxa._utils import APIClient, scope_matches
 
 
-DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com"
+DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com/v1"
 
 
 class Client(object):

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -36,7 +36,7 @@ class Client(object):
             client_id = self.client_id
         if client_secret is None:
             client_secret = self.client_secret
-        url = '/v1/token'
+        url = '/token'
         body = {
             'code': code,
             'client_id': client_id,
@@ -59,7 +59,7 @@ class Client(object):
         :raises fxa.errors.ClientError: if the provided token is invalid.
         :raises fxa.errors.TrustError: if the token scopes do not match.
         """
-        url = '/v1/verify'
+        url = '/verify'
         body = {
             'token': token
         }

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -9,6 +9,7 @@ from fxa._utils import APIClient, scope_matches
 
 
 DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com/v1"
+DEFAULT_VERSION_SUFFIX = "/v1"
 
 
 class Client(object):
@@ -19,6 +20,9 @@ class Client(object):
         self.client_secret = client_secret
         if server_url is None:
             server_url = DEFAULT_SERVER_URL
+        server_url = server_url.rstrip('/')
+        if not server_url.endswith(DEFAULT_VERSION_SUFFIX):
+            server_url += DEFAULT_VERSION_SUFFIX
         if isinstance(server_url, string_types):
             self.apiclient = APIClient(server_url)
         else:

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -9,7 +9,7 @@ from fxa._utils import APIClient, scope_matches
 
 
 DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com/v1"
-DEFAULT_VERSION_SUFFIX = "/v1"
+VERSION_SUFFIXES = ("/v1",)
 
 
 class Client(object):
@@ -21,8 +21,8 @@ class Client(object):
         if server_url is None:
             server_url = DEFAULT_SERVER_URL
         server_url = server_url.rstrip('/')
-        if not server_url.endswith(DEFAULT_VERSION_SUFFIX):
-            server_url += DEFAULT_VERSION_SUFFIX
+        if not server_url.endswith(VERSION_SUFFIXES):
+            server_url += VERSION_SUFFIXES[0]
         if isinstance(server_url, string_types):
             self.apiclient = APIClient(server_url)
         else:

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -15,6 +15,24 @@ from fxa.tests.utils import unittest
 TEST_SERVER_URL = "https://server/v1"
 
 
+class TestClientServerUrl(unittest.TestCase):
+    def test_trailing_slash_without_prefix_added_prefix(self):
+        client = Client('abc', 'cake', "https://server/")
+        self.assertEqual(client.apiclient.server_url, TEST_SERVER_URL)
+
+    def test_without_prefix_added_prefix(self):
+        client = Client('abc', 'cake', "https://server")
+        self.assertEqual(client.apiclient.server_url, TEST_SERVER_URL)
+
+    def test_trailing_slash_with_prefix(self):
+        client = Client('abc', 'cake', "https://server/v1/")
+        self.assertEqual(client.apiclient.server_url, TEST_SERVER_URL)
+
+    def test_with_prefix(self):
+        client = Client('abc', 'cake', "https://server/v1")
+        self.assertEqual(client.apiclient.server_url, TEST_SERVER_URL)
+
+
 class TestClientTradeCode(unittest.TestCase):
 
     server_url = TEST_SERVER_URL

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -12,7 +12,7 @@ from fxa.oauth import Client, scope_matches
 from fxa.tests.utils import unittest
 
 
-TEST_SERVER_URL = "https://server"
+TEST_SERVER_URL = "https://server/v1"
 
 
 class TestClientTradeCode(unittest.TestCase):


### PR DESCRIPTION
The v1 suffix is set on the oauth_uri configuration as explained in https://oauth-stable.dev.lcip.org/console/clients