### PR TITLE
Add basic API for accessing user profile data.

### DIFF
--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -270,7 +270,7 @@ class APIClient(object):
         if 500 <= resp.status_code < 600:
             raise fxa.errors.ServerError(body)
         if resp.status_code < 200 or resp.status_code >= 300:
-            msg = "API responded with unexpected status code: {}"
+            msg = "API responded with unexpected status code: {0}"
             raise fxa.errors.OutOfProtocolError(msg.format(resp.status_code))
 
         # Return the parsed JSON body for successful responses.
@@ -332,3 +332,18 @@ class HawkTokenAuth(requests.auth.AuthBase):
     def unbundle(self, namespace, payload):
         """Unbundle encrypted response data."""
         return fxa.crypto.unbundle(self.bundle_key, namespace, payload)
+
+
+class BearerTokenAuth(requests.auth.AuthBase):
+    """A requests auth hook implementing OAuth bearer-token-based auth.
+
+    This auth hook implements the simple "bearer token" auth scheme.
+    The provided token is passed directly in the Authorization header.
+    """
+
+    def __init__(self, token, apiclient=None):
+        self.token = token
+
+    def __call__(self, req):
+        req.headers["Authorization"] = "Bearer {0}".format(self.token)
+        return req

--- a/fxa/profile.py
+++ b/fxa/profile.py
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+from six import string_types
+
+from fxa.errors import OutOfProtocolError
+from fxa._utils import APIClient, BearerTokenAuth
+
+
+DEFAULT_SERVER_URL = "https://profile.accounts.firefox.com/v1"
+VERSION_SUFFIXES = ("/v1",)
+DEFAULT_CACHE_EXPIRY = 300
+
+
+class Client(object):
+    """Client for talking to the Firefox Accounts Profile server"""
+
+    def __init__(self, server_url=None):
+        if server_url is None:
+            server_url = DEFAULT_SERVER_URL
+        if not isinstance(server_url, string_types):
+            self.apiclient = server_url
+        else:
+            server_url = server_url.rstrip('/')
+            if not server_url.endswith(VERSION_SUFFIXES):
+                server_url += VERSION_SUFFIXES[0]
+            self.apiclient = APIClient(server_url)
+
+    @property
+    def server_url(self):
+        return self.apiclient.server_url
+
+    def get_profile(self, token):
+        """Get all profile data for the user associated with this token."""
+        url = '/profile'
+        resp = self.apiclient.get(url, auth=BearerTokenAuth(token))
+
+        for field in ("uid", "email", "avatar"):
+            if field not in resp:
+                error_msg = "{0} missing in profile response".format(field)
+                raise OutOfProtocolError(error_msg)
+
+        return resp
+
+    def get_email(self, token):
+        """Get the email address for the user associated with this token."""
+        url = '/email'
+        resp = self.apiclient.get(url, auth=BearerTokenAuth(token))
+        try:
+            return resp["email"]
+        except KeyError:
+            error_msg = "email missing in profile response"
+            raise OutOfProtocolError(error_msg)
+
+    def get_uid(self, token):
+        """Get the account uid for the user associated with this token."""
+        url = '/uid'
+        resp = self.apiclient.get(url, auth=BearerTokenAuth(token))
+        try:
+            return resp["uid"]
+        except KeyError:
+            error_msg = "uid missing in profile response"
+            raise OutOfProtocolError(error_msg)
+
+    def get_avatar_url(self, token):
+        """Get the url for a user's avatar picture."""
+        url = '/avatar'
+        resp = self.apiclient.get(url, auth=BearerTokenAuth(token))
+        try:
+            return resp["url"]
+        except KeyError:
+            error_msg = "url missing in profile response"
+            raise OutOfProtocolError(error_msg)

--- a/fxa/tests/test_profile.py
+++ b/fxa/tests/test_profile.py
@@ -1,0 +1,117 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import responses
+
+import fxa.errors
+from fxa.profile import Client
+
+from fxa.tests.utils import unittest
+
+
+TEST_SERVER_URL = "https://profile.server/v1"
+
+
+class TestProfileClientServerUrl(unittest.TestCase):
+
+    def test_trailing_slash_without_prefix_added_prefix(self):
+        client = Client("https://profile.server/")
+        self.assertEqual(client.server_url, TEST_SERVER_URL)
+
+    def test_without_prefix_added_prefix(self):
+        client = Client("https://profile.server")
+        self.assertEqual(client.server_url, TEST_SERVER_URL)
+
+    def test_trailing_slash_with_prefix(self):
+        client = Client("https://profile.server/v1/")
+        self.assertEqual(client.server_url, TEST_SERVER_URL)
+
+    def test_with_prefix(self):
+        client = Client("https://profile.server/v1")
+        self.assertEqual(client.server_url, TEST_SERVER_URL)
+
+
+class TestProfileClientOperations(unittest.TestCase):
+
+    server_url = TEST_SERVER_URL
+
+    def setUp(self):
+        self.client = Client(self.server_url)
+        self.token = "mock-bearer-token"
+
+    def _mock_response(self, path, body=None, **body_fields):
+        if body is None:
+            body = json.dumps(body_fields)
+        responses.add(
+            responses.GET,
+            "https://profile.server/v1" + path,
+            body=body,
+            content_type="application/json"
+        )
+
+    def assertRequestWasAuthorized(self, token):
+        authz = responses.calls[0].request.headers["Authorization"]
+        self.assertEqual(authz, "Bearer " + token)
+
+    @responses.activate
+    def test_get_profile(self):
+        self._mock_response(
+            "/profile",
+            uid="ABCDEF",
+            email="test@example.com",
+            avatar=None
+        )
+        resp = self.client.get_profile(self.token)
+        self.assertRequestWasAuthorized(self.token)
+        self.assertEqual(resp, {
+            "uid": "ABCDEF",
+            "email": "test@example.com",
+            "avatar": None,
+        })
+
+    @responses.activate
+    def test_get_profile_raises_error_on_missing_attributes(self):
+        self._mock_response("/profile", uid="ABCDEF")
+        with self.assertRaises(fxa.errors.OutOfProtocolError):
+            self.client.get_profile(self.token)
+
+    @responses.activate
+    def test_get_email(self):
+        self._mock_response("/email", email="test@example.com")
+        email = self.client.get_email(self.token)
+        self.assertRequestWasAuthorized(self.token)
+        self.assertEqual(email, "test@example.com")
+
+    @responses.activate
+    def test_get_email_raises_error_on_missing_attributes(self):
+        self._mock_response("/email", uid="ABCDEF")
+        with self.assertRaises(fxa.errors.OutOfProtocolError):
+            self.client.get_email(self.token)
+
+    @responses.activate
+    def test_get_uid(self):
+        self._mock_response("/uid", uid="123456")
+        uid = self.client.get_uid(self.token)
+        self.assertRequestWasAuthorized(self.token)
+        self.assertEqual(uid, "123456")
+
+    @responses.activate
+    def test_get_uid_raises_error_on_missing_attributes(self):
+        self._mock_response("/uid")
+        with self.assertRaises(fxa.errors.OutOfProtocolError):
+            self.client.get_uid(self.token)
+
+    @responses.activate
+    def test_get_avatar_url(self):
+        self._mock_response("/avatar", url="https://example.com/blah")
+        url = self.client.get_avatar_url(self.token)
+        self.assertRequestWasAuthorized(self.token)
+        self.assertEqual(url, "https://example.com/blah")
+
+    @responses.activate
+    def test_get_avatar_url_raises_error_on_missing_attributes(self):
+        self._mock_response("/avatar", id="corrupted-avatar")
+        with self.assertRaises(fxa.errors.OutOfProtocolError):
+            self.client.get_avatar_url(self.token)


### PR DESCRIPTION
Here's a super simple API for talking to the profile server, https://github.com/mozilla/fxa-profile-server/.  Pass in an OAuth token with appropriate scope, get back the associated profile info.  We might come up with some more over-arching "user" abstraction in future, but I think this will be a handy start for reliers.

@Natim r?