### PR TITLE
Cache classes should expose Unicode.

### DIFF
--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -196,9 +196,9 @@ class Client(object):
                     raise ScopeMismatchError(authorized_scope, scope)
 
             if self.cache is not None:
-                self.cache.set(key, json.dumps(resp).encode('utf-8'))
+                self.cache.set(key, json.dumps(resp))
         else:
-            resp = json.loads(resp.decode('utf-8'))
+            resp = json.loads(resp)
 
         return resp
 

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -398,7 +398,7 @@ class TestCachedClient(unittest.TestCase):
     def test_client_verify_code_cached_value_is_used(self):
         with mock.patch.object(self.client.cache, 'set') as mocked_set:
             with mock.patch.object(self.client.cache, 'get',
-                                   return_value=self.body.encode('utf-8')):
+                                   return_value=self.body):
                 # Second call
                 verification = self.client.verify_token(token='abc')
                 self.assertFalse(mocked_set.called)


### PR DESCRIPTION
Our cache classes should return unicode strings at this stage.