### PR TITLE
Add an extra require option for PyOpenSSL use with requests and use it for tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(VENVDIR)/COMPLETE: dev-requirements.txt
 	virtualenv --no-site-packages --python=`which python` --distribute $(VENVDIR)
 	$(INSTALL) --upgrade Distribute pip
 	$(INSTALL) -r ./dev-requirements.txt
-	$(PYTHON) ./setup.py develop
+	$(INSTALL) -e .[openssl]
 	touch $(VENVDIR)/COMPLETE
 
 .PHONY: test

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,18 @@ to provide easy support for the following features:
 
 But none of that is ready yet; caveat emptor.
 
+
+Installing PyFxA with OpenSSL support
+=====================================
+
+In case your Python version raises ``InsecurePlatformWarning`` you can
+install PyFxA with OpenSSL support:
+
+.. code-block::
+
+    pip install PyFxA[openssl]
+
+
 Firefox Accounts
 ================
 
@@ -27,6 +39,7 @@ Currently, basic auth-server operations should work like so:
     session = client.login("test@example.com", "MySecretPassword")
     cert = session.sign_certificate(myPublicKey)
     session.change_password("MySecretPassword", "ThisIsEvenMoreSecret")
+
 
 FxA OAuth Relier
 ================

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -19,3 +19,11 @@ def monkey_patch_for_gevent():
     import fxa._utils
     import grequests
     fxa._utils.requests = grequests
+
+try:
+    import OpenSSL  # NoQA
+except ImportError:
+    pass
+else:
+    from requests.packages import urllib3
+    urllib3.contrib.pyopenssl.inject_into_urllib3()

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -21,9 +21,11 @@ def monkey_patch_for_gevent():
     fxa._utils.requests = grequests
 
 try:
+    # Verify OpenSSL is installed
     import OpenSSL  # NoQA
+    # Verify we are using the Py2 urllib3 version
+    from requests.packages.urllib3.contrib import pyopenssl
 except ImportError:
     pass
 else:
-    from requests.packages import urllib3
-    urllib3.contrib.pyopenssl.inject_into_urllib3()
+    pyopenssl.inject_into_urllib3()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ REQUIREMENTS = [
     "six"
 ]
 
+OPENSSL_REQUIREMENTS = [
+    "pyopenssl",
+    "ndg-httpsclient",
+    "pyasn1"
+]
+
 setup(name="PyFxA",
       version=VERSION,
       description="Firefox Accounts client library for Python",
@@ -67,5 +73,8 @@ setup(name="PyFxA",
       include_package_data=True,
       zip_safe=False,
       install_requires=REQUIREMENTS,
+      extras_require={
+          'openssl': OPENSSL_REQUIREMENTS
+      },
       tests_require=test_requires,
       test_suite="fxa")


### PR DESCRIPTION
Following #22 this remove the warning about insecure SSL setup during tests as well as in production.