### PR TITLE
Read UTF-8 files in setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,17 @@ PY2 = sys.version_info[0] == 2
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-def read_file(filename):
-    """Open a related file and return its content."""
-    with codecs.open(os.path.join(here, filename), encoding='utf-8') as f:
-        content = f.read()
-    return content
+def open_file(filename):
+    """Open a related file with utf-8 encoding."""
+    return codecs.open(os.path.join(here, filename), encoding='utf-8')
 
-README = read_file(os.path.join(here, "README.rst"))
-CHANGES = read_file(os.path.join(here, "CHANGES.txt"))
+with open_file("README.rst") as f:
+    README = f.read()
 
-with codecs.open(os.path.join(here, "dev-requirements.txt"),
-                 encoding='utf-8') as f:
+with open_file("CHANGES.txt") as f:
+    CHANGES = f.read()
+
+with open_file("dev-requirements.txt") as f:
     requires = (ln.strip() for ln in f)
     test_requires = [ln for ln in requires if ln and not ln.startswith("#")]
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import codecs
 import os
 import sys
 from setuptools import setup, find_packages
@@ -8,13 +10,18 @@ PY2 = sys.version_info[0] == 2
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, "README.rst")) as f:
-    README = f.read()
 
-with open(os.path.join(here, "CHANGES.txt")) as f:
-    CHANGES = f.read()
+def read_file(filename):
+    """Open a related file and return its content."""
+    with codecs.open(os.path.join(here, filename), encoding='utf-8') as f:
+        content = f.read()
+    return content
 
-with open(os.path.join(here, "dev-requirements.txt")) as f:
+README = read_file(os.path.join(here, "README.rst"))
+CHANGES = read_file(os.path.join(here, "CHANGES.txt"))
+
+with codecs.open(os.path.join(here, "dev-requirements.txt"),
+                 encoding='utf-8') as f:
     requires = (ln.strip() for ln in f)
     test_requires = [ln for ln in requires if ln and not ln.startswith("#")]
 


### PR DESCRIPTION
This is to prevent installation failure with PIP when an UTF-8 characters is present in the README or the CHANGES files.