### PR TITLE
Add basic cache functionality to the Auth Plugins.

### DIFF
--- a/fxa/cache.py
+++ b/fxa/cache.py
@@ -1,0 +1,32 @@
+import time
+DEFAULT_CACHE_EXPIRY = 300
+
+
+class MemoryCache(object):
+    """Simple Memory cache."""
+
+    def __init__(self, ttl=DEFAULT_CACHE_EXPIRY):
+        self.ttl = ttl
+        self.cache = {}
+        self.expires_at = {}
+
+    def get(self, key):
+        self._cleanup()
+        value = self.cache.get(key)
+        return value
+
+    def set(self, key, value):
+        self.cache[key] = value
+        self.expires_at[key] = time.time() + self.ttl
+
+    def delete(self, key):
+        if key in self.cache:
+            del self.cache[key]
+
+        if key in self.expires_at:
+            del self.expires_at[key]
+
+    def _cleanup(self):
+        for key, expires_at in list(self.expires_at.items()):
+            if expires_at < time.time():
+                self.delete(key)

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -2,18 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
-import time
 
 from six import string_types
 from six.moves.urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
+from fxa.cache import MemoryCache, DEFAULT_CACHE_EXPIRY
 from fxa.errors import OutOfProtocolError, ScopeMismatchError
 from fxa._utils import APIClient, scope_matches, get_hmac
 
 
 DEFAULT_SERVER_URL = "https://oauth.accounts.firefox.com/v1"
 VERSION_SUFFIXES = ("/v1",)
-DEFAULT_CACHE_EXPIRY = 300
 TOKEN_HMAC_SECRET = 'PyFxA Token Cache Hmac Secret'
 
 
@@ -213,33 +212,3 @@ class Client(object):
             'token': token
         }
         self.apiclient.post(url, body)
-
-
-class MemoryCache(object):
-    """Simple Memory cache."""
-
-    def __init__(self, ttl=DEFAULT_CACHE_EXPIRY):
-        self.ttl = ttl
-        self.cache = {}
-        self.expires_at = {}
-
-    def get(self, key):
-        self._cleanup()
-        value = self.cache.get(key)
-        return value
-
-    def set(self, key, value):
-        self.cache[key] = value
-        self.expires_at[key] = time.time() + self.ttl
-
-    def delete(self, key):
-        if key in self.cache:
-            del self.cache[key]
-
-        if key in self.expires_at:
-            del self.expires_at[key]
-
-    def _cleanup(self):
-        for key, expires_at in list(self.expires_at.items()):
-            if expires_at < time.time():
-                self.delete(key)

--- a/fxa/plugins/requests.py
+++ b/fxa/plugins/requests.py
@@ -57,7 +57,7 @@ class FxABrowserIDAuth(AuthBase):
 
         cache_key = sha256(''.join((
             self.server_url, self.email,
-            self.password, self.audience))).hexdigest()
+            self.password, self.audience)).encode('utf-8')).hexdigest()
 
         data = self.cache.get(cache_key)
 
@@ -69,7 +69,7 @@ class FxABrowserIDAuth(AuthBase):
                 audience=self.audience,
                 duration=DEFAULT_CACHE_EXPIRY)
             _, keyB = session.fetch_keys()
-            client_state = hexlify(sha256(keyB).digest()[0:16])
+            client_state = hexlify(sha256(keyB).digest()[0:16]).decode('utf-8')
             self.cache.set(cache_key,
                            json.dumps([bid_assertion, client_state]))
         else:
@@ -125,7 +125,7 @@ class FxABearerTokenAuth(AuthBase):
         for key in (self.account_server_url, self.oauth_server_url,
                     self.email, self.password, self.scopes, self.client_id):
             if key:
-                cache_key.update(text_type(key))
+                cache_key.update(text_type(key).encode('utf-8'))
         cache_key = cache_key.hexdigest()
         token = self.cache.get(cache_key)
 

--- a/fxa/plugins/requests.py
+++ b/fxa/plugins/requests.py
@@ -3,17 +3,20 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import absolute_import
 
-from binascii import hexlify
-from hashlib import sha256
+import json
 import os
 
+from binascii import hexlify
+from hashlib import sha256
 from requests.auth import AuthBase
+from six import text_type
 from six.moves.urllib.parse import urlparse
 
 from fxa import core
 from fxa import oauth
 
 DEFAULT_CLIENT_ID = "5882386c6d801776"  # Firefox dev Client ID
+DEFAULT_CACHE_EXPIRY = 3600
 
 
 class FxABrowserIDAuth(AuthBase):
@@ -33,24 +36,44 @@ class FxABrowserIDAuth(AuthBase):
 
     """
     def __init__(self, email, password, audience=None, with_client_state=False,
-                 server_url=core.DEFAULT_SERVER_URL):
+                 server_url=core.DEFAULT_SERVER_URL, cache=True,
+                 ttl=None):
         self.email = email
         self.password = password
         self.audience = audience
         self.with_client_state = with_client_state
         self.server_url = server_url
 
-    def __call__(self, request):
-        client = core.Client(server_url=self.server_url)
-        session = client.login(self.email, self.password, keys=True)
+        self.cache = cache
+        if self.cache is True:
+            if ttl is None:
+                ttl = DEFAULT_CACHE_EXPIRY - 1
+            self.cache = oauth.MemoryCache(ttl)
 
+    def __call__(self, request):
         if self.audience is None:
             url = urlparse(request.url)
             self.audience = "%s://%s/" % (url.scheme, url.netloc)
 
-        bid_assertion = session.get_identity_assertion(self.audience)
-        _, keyB = session.fetch_keys()
-        client_state = hexlify(sha256(keyB).digest()[0:16])
+        cache_key = sha256(''.join((
+            self.server_url, self.email,
+            self.password, self.audience))).hexdigest()
+
+        data = self.cache.get(cache_key)
+
+        if not data:
+            client = core.Client(server_url=self.server_url)
+            session = client.login(self.email, self.password, keys=True)
+
+            bid_assertion = session.get_identity_assertion(
+                audience=self.audience,
+                duration=DEFAULT_CACHE_EXPIRY)
+            _, keyB = session.fetch_keys()
+            client_state = hexlify(sha256(keyB).digest()[0:16])
+            self.cache.set(cache_key,
+                           json.dumps([bid_assertion, client_state]))
+        else:
+            bid_assertion, client_state = json.loads(data)
         request.headers['Authorization'] = "BrowserID %s" % bid_assertion
 
         if self.with_client_state:
@@ -80,7 +103,8 @@ else:
 class FxABearerTokenAuth(AuthBase):
     def __init__(self, email, password, scopes=None, client_id=None,
                  account_server_url=core.DEFAULT_SERVER_URL,
-                 oauth_server_url=oauth.DEFAULT_SERVER_URL):
+                 oauth_server_url=oauth.DEFAULT_SERVER_URL,
+                 cache=True, ttl=DEFAULT_CACHE_EXPIRY):
         self.email = email
         self.password = password
 
@@ -92,18 +116,32 @@ class FxABearerTokenAuth(AuthBase):
         self.account_server_url = account_server_url
         self.oauth_server_url = oauth_server_url
 
+        self.cache = cache
+        if self.cache is True:
+            self.cache = oauth.MemoryCache(ttl)
+
     def __call__(self, request):
-        client = core.Client(server_url=self.account_server_url)
-        session = client.login(self.email, self.password, keys=True)
+        cache_key = sha256()
+        for key in (self.account_server_url, self.oauth_server_url,
+                    self.email, self.password, self.scopes, self.client_id):
+            if key:
+                cache_key.update(text_type(key))
+        cache_key = cache_key.hexdigest()
+        token = self.cache.get(cache_key)
 
-        url = urlparse(self.oauth_server_url)
-        audience = "%s://%s/" % (url.scheme, url.netloc)
+        if not token:
+            client = core.Client(server_url=self.account_server_url)
+            session = client.login(self.email, self.password, keys=True)
 
-        bid_assertion = session.get_identity_assertion(audience)
-        oauth_client = oauth.Client(server_url=self.oauth_server_url)
-        token = oauth_client.authorize_token(bid_assertion,
-                                             ' '.join(self.scopes),
-                                             self.client_id)
+            url = urlparse(self.oauth_server_url)
+            audience = "%s://%s/" % (url.scheme, url.netloc)
+
+            bid_assertion = session.get_identity_assertion(audience)
+            oauth_client = oauth.Client(server_url=self.oauth_server_url)
+            token = oauth_client.authorize_token(bid_assertion,
+                                                 ' '.join(self.scopes),
+                                                 self.client_id)
+            self.cache.set(cache_key, token)
         request.headers["Authorization"] = "Bearer %s" % token
         return request
 

--- a/fxa/tests/test_cache.py
+++ b/fxa/tests/test_cache.py
@@ -1,0 +1,19 @@
+import time
+
+from fxa.cache import MemoryCache
+from fxa.tests.utils import unittest
+
+
+class TestMemoryCache(unittest.TestCase):
+    def setUp(self):
+        self.cache = MemoryCache()
+
+    def test_can_get_what_has_been_set(self):
+        self.cache.set('Foo', 'Bar')
+        self.assertEqual(self.cache.get('Foo'), 'Bar')
+
+    def test_expires(self):
+        self.cache = MemoryCache(0.01)
+        self.cache.set('Foo', 'Bar')
+        time.sleep(0.01)
+        self.assertIsNone(self.cache.get('Foo'))

--- a/fxa/tests/test_cache.py
+++ b/fxa/tests/test_cache.py
@@ -17,3 +17,14 @@ class TestMemoryCache(unittest.TestCase):
         self.cache.set('Foo', 'Bar')
         time.sleep(0.01)
         self.assertIsNone(self.cache.get('Foo'))
+
+    def test_delete(self):
+        self.cache.set('Foo', 'Bar')
+        self.cache.delete('Foo')
+        self.assertIsNone(self.cache.get('Foo'))
+
+    def test_delete_expires(self):
+        self.cache = MemoryCache(0.01)
+        self.cache.set('Foo', 'Bar')
+        self.cache.delete('Foo')
+        self.assertIsNone(self.cache.get('Foo'))

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -5,11 +5,11 @@
 import json
 import mock
 import responses
-import time
 import six
 
 import fxa.errors
-from fxa.oauth import Client, scope_matches, MemoryCache
+from fxa.cache import MemoryCache
+from fxa.oauth import Client, scope_matches
 
 from fxa.tests.utils import unittest
 
@@ -342,21 +342,6 @@ class TestScopeMatch(unittest.TestCase):
         self.assertFalse(scope_matches(['abc:xyz'], 'abc'))
         self.assertFalse(scope_matches(['abc:xyz'], ['abc']))
         self.assertFalse(scope_matches(['abc:xyz', 'def'], ['abc', 'def']))
-
-
-class TestMemoryCache(unittest.TestCase):
-    def setUp(self):
-        self.cache = MemoryCache()
-
-    def test_can_get_what_has_been_set(self):
-        self.cache.set('Foo', 'Bar')
-        self.assertEqual(self.cache.get('Foo'), 'Bar')
-
-    def test_expires(self):
-        self.cache = MemoryCache(0.01)
-        self.cache.set('Foo', 'Bar')
-        time.sleep(0.01)
-        self.assertIsNone(self.cache.get('Foo'))
 
 
 class TestCachedClient(unittest.TestCase):

--- a/fxa/tests/test_requests_auth_plugin.py
+++ b/fxa/tests/test_requests_auth_plugin.py
@@ -70,7 +70,7 @@ class TestFxABrowserIDAuth(unittest.TestCase):
 
         client_patch.return_value.login.return_value. \
             get_identity_assertion.assert_called_with(
-                "http://www.example.com/")
+                audience="http://www.example.com/", duration=3600)
 
     @mock.patch('fxa.plugins.requests.core.Client',
                 return_value=mocked_core_client())

--- a/fxa/tests/test_requests_auth_plugin.py
+++ b/fxa/tests/test_requests_auth_plugin.py
@@ -3,7 +3,8 @@ import mock
 from os import urandom
 
 from fxa.cache import MemoryCache
-from fxa.plugins.requests import FxABrowserIDAuth, FxABearerTokenAuth
+from fxa.plugins.requests import (
+    FxABrowserIDAuth, FxABearerTokenAuth, get_cache_key)
 from fxa.tests.utils import unittest
 
 
@@ -153,3 +154,27 @@ class TestFxABearerTokenAuth(unittest.TestCase):
         assert not auth.cache
         r = auth(Request())
         self.assertIn('Authorization', r.headers)
+
+
+class GetCacheKeyTest(unittest.TestCase):
+    def test_get_cache_key_return_twice_the_same_key(self):
+        args = ['1', '2', 3]
+        self.assertEqual(get_cache_key(*args), get_cache_key(*args))
+
+    def test_get_cache_key_can_handle_list(self):
+        args = ['1', '2', [3, 'foobar']]
+        get_cache_key(*args)
+
+    def test_get_cache_key_can_handle_None(self):
+        args = ['1', None, [None, 'foobar']]
+        self.assertEqual(get_cache_key(*args), get_cache_key(*args))
+
+    def test_get_cache_key_can_handle_None_as_a_value(self):
+        args1 = ['1', None, 2]
+        args2 = ['1', 2]
+        self.assertNotEqual(get_cache_key(*args1), get_cache_key(*args2))
+
+    def test_get_cache_key_can_handle_value_as_string(self):
+        args1 = ['1', '2']
+        args2 = ['1', 2]
+        self.assertEqual(get_cache_key(*args1), get_cache_key(*args2))

--- a/fxa/tests/test_requests_auth_plugin.py
+++ b/fxa/tests/test_requests_auth_plugin.py
@@ -92,7 +92,7 @@ class TestFxABrowserIDAuth(unittest.TestCase):
 
     @mock.patch('fxa.plugins.requests.core.Client',
                 return_value=mocked_core_client())
-    def test_it_works_with_no_cache(self, client_patch):
+    def test_it_works_with_cache_deactivated(self, client_patch):
         auth = FxABrowserIDAuth(email="test@restmail.com",
                                 password="this is not a password",
                                 server_url="http://localhost:5000",
@@ -143,8 +143,8 @@ class TestFxABearerTokenAuth(unittest.TestCase):
                 return_value=mocked_core_client())
     @mock.patch('fxa.plugins.requests.oauth.Client',
                 return_value=mocked_oauth_client())
-    def test_it_works_with_no_cache(self, oauth_client_patch,
-                                    core_client_patch):
+    def test_it_works_with_cache_deactivated(self, oauth_client_patch,
+                                             core_client_patch):
         auth = FxABearerTokenAuth(
             email="test@restmail.com",
             password="this is not a password",

--- a/fxa/tests/test_requests_auth_plugin.py
+++ b/fxa/tests/test_requests_auth_plugin.py
@@ -2,6 +2,7 @@ from binascii import hexlify
 import mock
 from os import urandom
 
+from fxa.cache import MemoryCache
 from fxa.plugins.requests import FxABrowserIDAuth, FxABearerTokenAuth
 from fxa.tests.utils import unittest
 
@@ -81,6 +82,25 @@ class TestFxABrowserIDAuth(unittest.TestCase):
         r = auth(Request())
         self.assertNotIn('X-Client-State', r.headers)
 
+    @mock.patch('fxa.plugins.requests.core.Client',
+                return_value=mocked_core_client())
+    def test_memory_cache_is_set_by_default(self, client_patch):
+        auth = FxABrowserIDAuth(email="test@restmail.com",
+                                password="this is not a password",
+                                server_url="http://localhost:5000")
+        assert type(auth.cache) is MemoryCache
+
+    @mock.patch('fxa.plugins.requests.core.Client',
+                return_value=mocked_core_client())
+    def test_it_works_with_no_cache(self, client_patch):
+        auth = FxABrowserIDAuth(email="test@restmail.com",
+                                password="this is not a password",
+                                server_url="http://localhost:5000",
+                                cache=False)
+        assert not auth.cache
+        r = auth(Request())
+        self.assertIn('Authorization', r.headers)
+
 
 class TestFxABearerTokenAuth(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -110,3 +130,26 @@ class TestFxABearerTokenAuth(unittest.TestCase):
         core_client_patch.return_value.login.return_value. \
             get_identity_assertion.assert_called_with(
                 "https://oauth.com/")
+
+    @mock.patch('fxa.plugins.requests.core.Client',
+                return_value=mocked_core_client())
+    @mock.patch('fxa.plugins.requests.oauth.Client',
+                return_value=mocked_oauth_client())
+    def test_memory_cache_is_set_by_default(self, oauth_client_patch,
+                                            core_client_patch):
+        assert type(self.auth.cache) is MemoryCache
+
+    @mock.patch('fxa.plugins.requests.core.Client',
+                return_value=mocked_core_client())
+    @mock.patch('fxa.plugins.requests.oauth.Client',
+                return_value=mocked_oauth_client())
+    def test_it_works_with_no_cache(self, oauth_client_patch,
+                                    core_client_patch):
+        auth = FxABearerTokenAuth(
+            email="test@restmail.com",
+            password="this is not a password",
+            account_server_url="https://accounts.com/auth/v1",
+            oauth_server_url="https://oauth.com/oauth/v1", cache=False)
+        assert not auth.cache
+        r = auth(Request())
+        self.assertIn('Authorization', r.headers)


### PR DESCRIPTION
This is to prevent calling the Firefox Account infrastructure too much when using the same Auth backend for multiple requests.