### PR TITLE
Do not rely on the package to be installed.

### DIFF
--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -6,9 +6,8 @@
 Python library for interacting with the Firefox Accounts ecosystem.
 
 """
-import pkg_resources
 
-__version__ = pkg_resources.get_distribution("PyFxA").version
+__version__ = '0.0.9.dev0'
 __ver_tuple__ = tuple(__version__.split('.'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import os
 import sys
 from setuptools import setup, find_packages
 
+import fxa
+
 PY2 = sys.version_info[0] == 2
 
 # Read package meta-data from the containing directory.
@@ -50,7 +52,7 @@ else:
     OPENSSL_REQUIREMENTS = []
 
 setup(name="PyFxA",
-      version='0.0.9.dev0',
+      version=fxa.__version__,
       description="Firefox Accounts client library for Python",
       long_description=README + "\n\n" + CHANGES,
       classifiers=[


### PR DESCRIPTION
Otherwise, some tools (e.g. fedora automatic packaging, loads) are not able to
use PyFxA as a dependency due to the fact that they don't install it in
a standard way.

r? @tarekziade 