### PR TITLE
add verify_email_code(uid, code) to client

### DIFF
--- a/fxa/core.py
+++ b/fxa/core.py
@@ -285,7 +285,7 @@ class Session(object):
         return resp
 
     def verify_email_code(self, code):
-        return self.client.verify_email_code(self.uid, code) # note: not authenticated
+        return self.client.verify_email_code(self.uid, code)  # note: not authenticated
 
     def resend_email_code(self, **kwds):
         body = {}

--- a/fxa/core.py
+++ b/fxa/core.py
@@ -213,6 +213,13 @@ class Client(object):
         auth = HawkTokenAuth(token, "passwordForgotToken", self.apiclient)
         return self.apiclient.get(url, auth=auth)
 
+    def verify_email_code(self, uid, code):
+        body = {
+            "uid": uid,
+            "code": code,
+        }
+        url = "/recovery_email/verify_code"
+        return self.apiclient.post(url, body)
 
 class Session(object):
 

--- a/fxa/core.py
+++ b/fxa/core.py
@@ -285,12 +285,7 @@ class Session(object):
         return resp
 
     def verify_email_code(self, code):
-        body = {
-            "uid": self.uid,
-            "code": code,
-        }
-        url = "/recovery_email/verify_code"
-        self.apiclient.post(url, body)  # note: not authenticated
+        return self.client.verify_email_code(self.uid, code) # note: not authenticated
 
     def resend_email_code(self, **kwds):
         body = {}

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -156,6 +156,20 @@ class TestCoreClient(unittest.TestCase):
             stretchpwd=DUMMY_STRETCHED_PASSWORD
         )
 
+    def test_email_code_verification(self):
+        self.client = Client(self.server_url)
+        # Create a fresh testing account.
+        self.acct = TestEmailAccount()
+        self.client.create_account(
+            email=self.acct.email,
+            stretchpwd=DUMMY_STRETCHED_PASSWORD,
+        )
+        m = self.acct.wait_for_email(lambda m: "x-uid" in m["headers"] and "x-verify-code" in m["headers"])
+        if not m:
+            raise RuntimeError("Verification email was not received")
+        # If everything went well, verify_email_code should return an empty json object
+        response = self.client.verify_email_code(m["headers"]["x-uid"], m["headers"]["x-verify-code"])
+        self.assertEquals(response, {})
 
 class TestCoreClientSession(unittest.TestCase):
 


### PR DESCRIPTION
You do not actually need username and password to use this function. I am currently using it to confirm certain fxa accounts using the data (uid and code) from the confirmation link in the email.

Do you think it makes sense for upstream too? If not, please ignore this :smile:

Cheers,
Juanito