### PR TITLE
Improve PyFxA releases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 0.4.0 (unreleased)
 ==================
 
-- No changes yet.
+- Use `pkg_resources` to handle package version. (#45)
 
 
 0.3.0 (2016-09-07)

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -6,8 +6,9 @@
 Python library for interacting with the Firefox Accounts ecosystem.
 
 """
+import pkg_resources
 
-__version__ = '0.4.0.dev0'
+__version__ = pkg_resources.get_distribution("PyFxA").version
 __ver_tuple__ = tuple(__version__.split('.'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-import fxa
-
 PY2 = sys.version_info[0] == 2
 
 # Read package meta-data from the containing directory.
@@ -50,7 +48,7 @@ if sys.version_info < (2, 7, 9):
 
 
 setup(name="PyFxA",
-      version=fxa.__version__,
+      version='0.4.0.dev0',
       description="Firefox Accounts client library for Python",
       long_description=README + "\n\n" + CHANGES,
       classifiers=[


### PR DESCRIPTION
This change have been made previously to comply with loadsv1 which is not supported anymore. I would like to revert it because it makes releases a lot easier.