### PR TITLE
Avoid walking entire cache on each get, and make it thread-safe.

### DIFF
--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -6,6 +6,7 @@
 Python library for interacting with the Firefox Accounts ecosystem.
 
 """
+
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution("PyFxA").version
@@ -16,6 +17,7 @@ def monkey_patch_for_gevent():
     import fxa._utils
     import grequests
     fxa._utils.requests = grequests
+
 
 try:
     # Verify we are using the Py2 urllib3 version with OpenSSL installed

--- a/fxa/__main__.py
+++ b/fxa/__main__.py
@@ -214,5 +214,6 @@ def main(args=None):
     if fd_is_to_close:
         fd.close()
 
+
 if __name__ == "__main__":
     main()

--- a/fxa/cache.py
+++ b/fxa/cache.py
@@ -1,4 +1,7 @@
 import time
+import threading
+import collections
+
 DEFAULT_CACHE_EXPIRY = 300
 
 
@@ -8,25 +11,47 @@ class MemoryCache(object):
     def __init__(self, ttl=DEFAULT_CACHE_EXPIRY):
         self.ttl = ttl
         self.cache = {}
-        self.expires_at = {}
+        self.expiry_queue = collections.deque()
+        self.lock = threading.Lock()
 
-    def get(self, key):
-        self._cleanup()
-        value = self.cache.get(key)
+    def get(self, key, now=None):
+        with self.lock:
+            if now is None:
+                now = time.time()
+            self._purge_expired_items(now)
+            value, expires_at = self.cache.get(key, (None, 0))
+            # There's a small chance that an expired item has
+            # not been removed yet, due to queue ordering weirdness.
+            if expires_at < now:
+                return None
         return value
 
-    def set(self, key, value):
-        self.cache[key] = value
-        self.expires_at[key] = time.time() + self.ttl
+    def set(self, key, value, now=None):
+        with self.lock:
+            if now is None:
+                now = time.time()
+            expires_at = now + self.ttl
+            self.cache[key] = (value, expires_at)
+            self.expiry_queue.append((expires_at, key))
 
     def delete(self, key):
         if key in self.cache:
             del self.cache[key]
 
-        if key in self.expires_at:
-            del self.expires_at[key]
-
-    def _cleanup(self):
-        for key, expires_at in list(self.expires_at.items()):
-            if expires_at < time.time():
-                self.delete(key)
+    def _purge_expired_items(self, now):
+        while self.expiry_queue:
+            (expires_at, key) = self.expiry_queue[0]
+            if expires_at >= now:
+                break
+            # The item is expired, remove it.
+            # Careful though, it may have been replaced
+            # with a newer value after its expiry was enqueued.
+            self.expiry_queue.popleft()
+            try:
+                item = self.cache.pop(key)
+            except KeyError:
+                pass
+            else:
+                if item[1] > now:
+                    # It's been replaced, put it back.
+                    self.cache[key] = item

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -252,8 +252,8 @@ class TestCoreClientSession(unittest.TestCase):
         cert = self.session.sign_certificate(pubkey, duration=4000)
         cert_exp = browserid.utils.decode_json_bytes(cert.split(".")[1])["exp"]
         ttl = round(float(cert_exp - millis) / 1000)
-        self.assertGreaterEqual(ttl, 3)
-        self.assertLessEqual(ttl, 5)
+        self.assertGreaterEqual(ttl, 2)
+        self.assertLessEqual(ttl, 6)
 
     def test_change_password(self):
         # Change the password.
@@ -288,10 +288,10 @@ class TestCoreClientSession(unittest.TestCase):
 
         # Validate cert expiry
         ttl = round(float(cert['exp'] - millis) / 1000)
-        self.assertGreaterEqual(ttl, 1233)
-        self.assertLessEqual(ttl, 1235)
+        self.assertGreaterEqual(ttl, 1232)
+        self.assertLessEqual(ttl, 1236)
 
         # Validate assertion expiry
         ttl = round(float(assertion['exp'] - millis) / 1000)
-        self.assertGreaterEqual(ttl, 1233)
-        self.assertLessEqual(ttl, 1235)
+        self.assertGreaterEqual(ttl, 1232)
+        self.assertLessEqual(ttl, 1236)


### PR DESCRIPTION
While looking into #48, I noticed that the current default cache implementation touches every item in the cache on every `get()`, in order to enforce expiry.  This PR makes two changes:

* Use a queue for processing expiry, so we don't have to touch every item.
* Use an explicit Lock to ensure we're thread-safe by default.

@leplatrem does this seem worthwhile?