### PR TITLE
Make it easy to include `?service=foo` when signing a certificate.

### DIFF
--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -295,3 +295,11 @@ class TestCoreClientSession(unittest.TestCase):
         ttl = round(float(assertion['exp'] - millis) / 1000)
         self.assertGreaterEqual(ttl, 1232)
         self.assertLessEqual(ttl, 1236)
+
+    def test_get_identity_assertion_accepts_service(self):
+        # We can't observe any side-effects of sending the service query param,
+        # but we can test that it doesn't error out.
+        assertion = self.session.get_identity_assertion("http://example.com",
+                                                        service="test-me")
+        data = browserid.verify(assertion, audience="http://example.com")
+        self.assertEquals(data["status"], "okay")

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -258,6 +258,23 @@ class TestAuthClientAuthorizeCode(unittest.TestCase):
             "state": "x",
         })
 
+    @responses.activate
+    def test_authorize_code_with_session_object(self):
+        session = mock.Mock()
+        session.get_identity_assertion.return_value = "IDENTITY"
+        code = self.client.authorize_code(session)
+        session.get_identity_assertion.assert_called_once_with(
+            audience=TEST_SERVER_URL,
+            service=self.client.client_id
+        )
+        self.assertEquals(code, "qed")
+        req_body = json.loads(_decoded(responses.calls[0].request.body))
+        self.assertEquals(req_body, {
+            "assertion": "IDENTITY",
+            "client_id": self.client.client_id,
+            "state": "x",
+        })
+
 
 class TestAuthClientAuthorizeToken(unittest.TestCase):
 
@@ -306,6 +323,24 @@ class TestAuthClientAuthorizeToken(unittest.TestCase):
         self.assertEquals(req_body, {
             "assertion": assertion,
             "client_id": "cba",
+            "state": "x",
+            "response_type": "token",
+        })
+
+    @responses.activate
+    def test_authorize_token_with_session_object(self):
+        session = mock.Mock()
+        session.get_identity_assertion.return_value = "IDENTITY"
+        token = self.client.authorize_token(session)
+        session.get_identity_assertion.assert_called_once_with(
+            audience=TEST_SERVER_URL,
+            service=self.client.client_id
+        )
+        self.assertEquals(token, "izatoken")
+        req_body = json.loads(_decoded(responses.calls[0].request.body))
+        self.assertEquals(req_body, {
+            "assertion": "IDENTITY",
+            "client_id": self.client.client_id,
             "state": "x",
             "response_type": "token",
         })


### PR DESCRIPTION
Here's an attempt to fix #50; @kewisch if you get a chance to try it out I'd appreciate it.

The idea is to make it easy to include the `?service=foo` query parameter when signing an identity certificate.  You can pass it manually, or you can just pass in a `Session` object and let the oauth client do it for you.  The code here:

  https://github.com/kewisch/pyamo/blob/master/pyamo/utils.py#L67-L71

Would become just:

```
    session = client.login(username, password)
    oauth_client = fxa.oauth.Client(server_url=oauth_url)
    return oauth_client.authorize_code(session, scope, client_id)
```

Thoughts?