### PR TITLE
Add basic support for PKCE and keys_jwk in OAuth flow.

### DIFF
--- a/fxa/__main__.py
+++ b/fxa/__main__.py
@@ -90,6 +90,16 @@ def main(args=None):
                         required=False,
                         default=DEFAULT_CLIENT_ID)
 
+    parser.add_argument('--client-secret',
+                        help='Firefox Account OAuth client secret.',
+                        dest='client_secret',
+                        required=False)
+
+    parser.add_argument('--use-pkce',
+                        help='Whether to use PKCE in OAuth code grant flow.',
+                        dest='use_pkce',
+                        action='store_true')
+
     parser.add_argument('--scopes',
                         help='Firefox Account OAuth scopes.',
                         dest='scopes',
@@ -189,13 +199,18 @@ def main(args=None):
                   if s.strip()]
         client_id = args['client_id']
         unblock_code = args['unblock_code']
+        client_secret = args['client_secret']
+        use_pkce = args['use_pkce']
 
         logger.info('Generating the Bearer Token.')
 
         try:
             token = get_bearer_token(email, password, scopes,
                                      account_server_url,
-                                     oauth_server_url, client_id,
+                                     oauth_server_url,
+                                     client_id,
+                                     client_secret,
+                                     use_pkce,
                                      unblock_code)
         except ClientError as e:
             logger.error(e)

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -278,7 +278,7 @@ class TestCoreClientSession(unittest.TestCase):
         cert_exp = browserid.utils.decode_json_bytes(cert.split(".")[1])["exp"]
         ttl = round(float(cert_exp - millis) / 1000)
         self.assertGreaterEqual(ttl, 2)
-        self.assertLessEqual(ttl, 6)
+        self.assertLessEqual(ttl, 30)
 
     def test_change_password(self):
         # Change the password.
@@ -313,13 +313,13 @@ class TestCoreClientSession(unittest.TestCase):
 
         # Validate cert expiry
         ttl = round(float(cert['exp'] - millis) / 1000)
-        self.assertGreaterEqual(ttl, 1232)
-        self.assertLessEqual(ttl, 1236)
+        self.assertGreaterEqual(ttl, 1230)
+        self.assertLessEqual(ttl, 1260)
 
         # Validate assertion expiry
         ttl = round(float(assertion['exp'] - millis) / 1000)
-        self.assertGreaterEqual(ttl, 1232)
-        self.assertLessEqual(ttl, 1236)
+        self.assertGreaterEqual(ttl, 1230)
+        self.assertLessEqual(ttl, 1260)
 
     def test_get_identity_assertion_accepts_service(self):
         # We can't observe any side-effects of sending the service query param,

--- a/fxa/tests/test_requests_auth_plugin.py
+++ b/fxa/tests/test_requests_auth_plugin.py
@@ -127,13 +127,18 @@ class TestFxABearerTokenAuth(unittest.TestCase):
                         "Authorization headers does not start with Bearer")
 
         core_client_patch.assert_called_with(
-            server_url="https://accounts.com/auth/v1")
+            server_url="https://accounts.com/auth/v1"
+        )
         oauth_client_patch.assert_called_with(
-            server_url="https://oauth.com/oauth/v1")
+            "53210789456",
+            None,
+            server_url="https://oauth.com/oauth/v1"
+        )
 
-        core_client_patch.return_value.login.return_value. \
-            get_identity_assertion.assert_called_with(
-                "https://oauth.com/")
+        oauth_client_patch.return_value.authorize_token.assert_called_with(
+            core_client_patch.return_value.login.return_value,
+            "profile"
+        )
 
     @mock.patch('fxa.core.Client',
                 return_value=mocked_core_client())

--- a/fxa/tests/test_tools.py
+++ b/fxa/tests/test_tools.py
@@ -49,7 +49,9 @@ class TestGetBearerToken(unittest.TestCase):
                          account_server_url="account_server_url",
                          oauth_server_url="oauth_server_url")
         oauth_client().authorize_token.assert_called_with(
-            'abcd', 'profile', '543210789456')
+            core_client.return_value.login.return_value,
+            'profile'
+        )
 
 
 class TestGetBrowserIDAssertion(unittest.TestCase):

--- a/fxa/tools/create_user.py
+++ b/fxa/tools/create_user.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import base64
 import os
+import re
 import hmac
 
 from fxa import core
@@ -14,7 +15,7 @@ FXA_ERROR_ACCOUNT_EXISTS = 101
 
 def create_new_fxa_account(fxa_user_salt=None, account_server_url=None,
                            prefix="fxa", content_server_url=None):
-    if account_server_url and 'stage' in account_server_url:
+    if account_server_url and re.search('(dev)|(stage)', account_server_url):
         if not fxa_user_salt:
             fxa_user_salt = os.urandom(36)
         else:
@@ -35,7 +36,7 @@ def create_new_fxa_account(fxa_user_salt=None, account_server_url=None,
         finally:
             return email, password
     else:
-        message = ("You are not using stage (%s), make sure your FxA test "
-                   "account exists: %s" % (account_server_url,
-                                           content_server_url))
+        message = ("You are not using dev or stage (%s), make sure your FxA "
+                   "test account exists: %s" % (account_server_url,
+                                                content_server_url))
         raise ValueError(message)


### PR DESCRIPTION
WIP, needs tests, but fixes #58.

@Natim with this change, I can successfully run the following to get a bearer token:

```
 python -m fxa --bearer --account-server="https://latest-keys.dev.lcip.org/auth" --oauth-server="https://oauth-latest-keys.dev.lcip.org/" --scopes="profile https://identity.mozilla.org/apps/notes" --client-id=c6d74070a481bc10 -c --use-pkce
```

It doesn't have support for generating scoped keys yet, though.