### PR TITLE
Tell test runners not to collect the TestEmailAccount class.

### DIFF
--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -177,7 +177,7 @@ class TestCoreClient(unittest.TestCase):
         self.assertEquals(response, {})
 
     def test_send_unblock_code(self):
-        acct = TestEmailAccount(email="blockUnblockCode@restmail.net")
+        acct = TestEmailAccount(email="block-{uniq}@{hostname}")
         self.client.create_account(
             email=acct.email,
             stretchpwd=DUMMY_STRETCHED_PASSWORD,

--- a/fxa/tests/utils.py
+++ b/fxa/tests/utils.py
@@ -61,6 +61,8 @@ class TestEmailAccount(object):
     you want these to be filled in automatically.
     """
 
+    __test__ = False  # Prevent testrunners from collecting this class.
+
     DEFAULT_SERVER_URL = "http://restmail.net"
 
     def __init__(self, email=None, server_url=None):


### PR DESCRIPTION
Hopefully fixes #60; @chartjes let me know if this helps?