### PR TITLE
Add support for TOTP

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ grequests
 mock
 responses
 unittest2
+pyotp

--- a/fxa/core.py
+++ b/fxa/core.py
@@ -334,8 +334,7 @@ class Session(object):
 
     def totp_delete(self):
         url = "/totp/destroy"
-        resp = self.apiclient.post(url, {}, auth=self._auth)
-        return resp["exists"]
+        return self.apiclient.post(url, {}, auth=self._auth)
 
     def totp_verify(self, code):
         url = "/session/verify/totp"
@@ -343,6 +342,9 @@ class Session(object):
             "code": code,
         }
         resp = self.apiclient.post(url, body, auth=self._auth)
+        if resp["success"]:
+            self.verified = True
+
         return resp["success"]
 
     def sign_certificate(self, public_key, duration=DEFAULT_CERT_DURATION,

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -6,6 +6,8 @@ import time
 from six import binary_type
 from six.moves.urllib.parse import urlparse
 
+import pyotp
+
 from browserid import jwt
 import browserid.tests.support
 import browserid.utils
@@ -328,3 +330,27 @@ class TestCoreClientSession(unittest.TestCase):
                                                         service="test-me")
         data = browserid.verify(assertion, audience="http://example.com")
         self.assertEquals(data["status"], "okay")
+
+    def test_totp(self):
+        resp = self.session.totp_create()
+
+        # Double create causes a client error
+        with self.assertRaises(fxa.errors.ClientError):
+            self.session.totp_create()
+
+        # Created but not verified returns false
+        self.assertFalse(self.session.totp_exists())
+
+        # Verify the code
+        code = pyotp.TOTP(resp["secret"]).now()
+        self.assertTrue(self.session.totp_verify(code))
+        self.assertTrue(self.session.verified)
+
+        # Should exist now
+        self.assertTrue(self.session.totp_exists())
+
+        # Remove the code
+        resp = self.session.totp_delete()
+
+        # And now should not exist
+        self.assertFalse(self.session.totp_exists())

--- a/fxa/tests/test_core.py
+++ b/fxa/tests/test_core.py
@@ -338,8 +338,11 @@ class TestCoreClientSession(unittest.TestCase):
         with self.assertRaises(fxa.errors.ClientError):
             self.session.totp_create()
 
-        # Created but not verified returns false
+        # Created but not verified returns false (and deletes the token)
         self.assertFalse(self.session.totp_exists())
+
+        # Creating again should work this time
+        resp = self.session.totp_create()
 
         # Verify the code
         code = pyotp.TOTP(resp["secret"]).now()


### PR DESCRIPTION
Uploading this for comment. I've added support for 2fa/totp, but I'm struggling with the test. My understanding was that all I need to do to enable it is to create the token and possibly verify a code, and then it should work.

I'm probably confusing the "verified" state, I'm not sure if that is just for verifying the account after creation, or if it is the state the session is in after the TOTP code was verified.

The tests fail on the verifying step with "A TOTP token not found", so it seems the token creation failed somehow, or did not stick.

Would be delighted for the right hints on how to actually enable 2fa on an account.