### PR TITLE
Add trove classifiers for versions of Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ setup(name="PyFxA",
       classifiers=[
           "Intended Audience :: Developers",
           "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.6",
           "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
       ],
       entry_points={


### PR DESCRIPTION
This will allow dependency checkers like pyup.io to know that PyFxA is Python 3 compatible.