### PR TITLE
Don't modify self.server_url when making a request.

### DIFF
--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -246,9 +246,10 @@ class APIClient(object):
         # Apply defaults and perform the request.
         while url.startswith("/"):
             url = url[1:]
-        if not self.server_url.endswith("/"):
-            self.server_url = self.server_url + "/"
-        url = urljoin(self.server_url, url)
+        if self.server_url.endswith("/"):
+            url = urljoin(self.server_url, url)
+        else:
+            url = urljoin(self.server_url + "/", url)
         if self.timeout is not None:
             kwds.setdefault("timeout", self.timeout)
 


### PR DESCRIPTION
I suspect this is the cause of #73, and would also explain why that issue was only sporadically reproducible. There's probably a bigger cleanup we could do here to avoid having to make this check at all, but this small fix seems like a good start.  @pmac r?