### PR TITLE
Support `ttl` when trading a code for an access token.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ python:
     - "2.7"
     - "3.6"
 install:
-    - pip install -r ./dev-requirements.txt
+    - pip install -U pip
     - python setup.py build
 script:
+    - pip install -r ./dev-requirements.txt
+    - python setup.py build
     - python setup.py test
 notifications:
     irc:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 grequests
 mock;python_version<"3.3"
 responses
-pytest
-pytest-runner
+pytest==4.6.4
+pytest-runner==4.5.1
 pytest-cov
 pytest-flake8
 pyotp

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -93,13 +93,14 @@ class Client(object):
         return urlunparse(authorization_url._replace(query=query_str))
 
     def trade_code(self, code, client_id=None, client_secret=None,
-                   code_verifier=None):
+                   code_verifier=None, ttl=None):
         """Trade the authentication code for a longer lived token.
 
         :param code: the authentication code from the oauth redirect dance.
         :param client_id: the string generated during FxA client registration.
         :param client_secret: the related secret string.
         :param code_verifier: optional PKCE code verifier.
+        :param ttl: optional ttl in seconds, the access token is valid for.
         :returns: a dict with user id and authorized scopes for this token.
         """
         if client_id is None:
@@ -115,6 +116,8 @@ class Client(object):
             body["client_secret"] = client_secret
         if code_verifier is not None:
             body["code_verifier"] = code_verifier
+        if ttl is not None:
+            body["ttl"] = ttl
         resp = self.apiclient.post(url, body)
 
         if 'access_token' not in resp:

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -133,6 +133,24 @@ class TestClientTradeCode(unittest.TestCase):
           'code_verifier': 'verifyme',
         })
 
+    @responses.activate
+    def test_trade_token_can_take_ttl(self):
+        responses.add(responses.POST,
+                      'https://server/v1/token',
+                      body='{"access_token": "tokay"}',
+                      content_type='application/json')
+        tokens = self.client.trade_code(
+            code='1234',
+            ttl=120,
+        )
+        self.assertEqual(tokens, {"access_token": "tokay"})
+        self.assertEqual(self._get_request_body(), {
+          'client_id': 'abc',
+          'client_secret': 'cake',
+          'code': '1234',
+          'ttl': 120
+        })
+
 
 class TestAuthClientVerifyCode(unittest.TestCase):
 


### PR DESCRIPTION
ref mozmeao/basket#256

@rfk - r?

cc @pmac 