### PR TITLE
Send `reason` and `verificationMethod` fields in login request.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,13 @@ CHANGELOG
 
 This document describes changes between each past release.
 
+PENDING
+=======
+
+- Add support for `reason` and `verification_method` keyword arguments
+  to the `login` method.
+
+
 0.7.4 (2020-06-10)
 ==================
 

--- a/fxa/core.py
+++ b/fxa/core.py
@@ -74,11 +74,13 @@ class Client(object):
             auth_timestamp=resp["authAt"],
         )
 
-    def login(self, email, password=None, stretchpwd=None, keys=False, unblock_code=None):
+    def login(self, email, password=None, stretchpwd=None, keys=False, unblock_code=None,
+              verification_method=None, reason="login"):
         stretchpwd = self._get_stretched_password(email, password, stretchpwd)
         body = {
             "email": email,
             "authPW": hexstr(derive_key(stretchpwd, "authPW")),
+            "reason": reason,
         }
         url = "/account/login"
         if keys:
@@ -86,6 +88,8 @@ class Client(object):
 
         if unblock_code:
             body["unblockCode"] = unblock_code
+        if verification_method:
+            body["verificationMethod"] = verification_method
 
         resp = self.apiclient.post(url, body)
         # XXX TODO: somehow sanity-check the schema on this endpoint


### PR DESCRIPTION
Fixes #82, at least in my manual testing. I think that some new security heuristics on the server are flagging login requests without a "reason" field as invalid.