### PR TITLE
Loosen JWT `typ`-matching rules to conform to RFC recommendations.

### DIFF
--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -78,6 +78,9 @@ def scope_matches(provided, required):
     :param required: the scope required (e.g. by the application).
     :returns: ``True`` if all required scopes are provided, ``False`` if not.
     """
+    if isinstance(provided, six.string_types):
+        raise ValueError("Provided scopes must be a list, not a single string")
+
     if not isinstance(required, (list, tuple)):
         required = [required]
 

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -233,7 +233,12 @@ class Client(object):
         decoded = jwt.decode(
             token, pubkey, algorithms=['RS256'], options={'verify_aud': False}
         )
-        if jwt.get_unverified_header(token).get('typ') != 'at+jwt':
+        # Ref https://tools.ietf.org/html/rfc7515#section-4.1.9 the `typ` header
+        # is lowercase and has an implicit default `application/` prefix.
+        typ = jwt.get_unverified_header(token).get('typ', '')
+        if '/' not in typ:
+            typ = 'application/' + typ
+        if typ.lower() != 'application/at+jwt':
             raise TrustError
         return {
             'user': decoded.get('sub'),

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -243,7 +243,7 @@ class Client(object):
         return {
             'user': decoded.get('sub'),
             'client_id': decoded.get('client_id'),
-            'scope': decoded.get('scope'),
+            'scope': decoded.get('scope', '').split(),
             'generation': decoded.get('fxa-generation'),
             'profile_changed_at': decoded.get('fxa-profileChangedAt')
         }

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -678,6 +678,27 @@ class TestJwtToken(unittest.TestCase):
                                  resulted in a call to /verify, but it did.")
 
     @responses.activate
+    def test_good_jwt_token_with_correct_scope(self):
+        private_key = self.get_file_contents("private-key.json")
+        token = self._make_jwt({
+            "sub": "asdf",
+            "scope": "qwer tee",
+            "client_id": "foo"
+        }, private_key)
+        self.client.verify_token(token, scope="tee")
+
+    @responses.activate
+    def test_good_jwt_token_with_incorrect_scope(self):
+        private_key = self.get_file_contents("private-key.json")
+        token = self._make_jwt({
+            "sub": "asdf",
+            "scope": "qwer",
+            "client_id": "foo"
+        }, private_key)
+        with self.assertRaises(fxa.errors.TrustError):
+            self.client.verify_token(token, scope="tee")
+
+    @responses.activate
     def test_wrong_key_jwt_token(self):
         self.verify_will_succeed = False
         bad_key = self.get_file_contents("bad-key.json")

--- a/fxa/tests/test_oauth.py
+++ b/fxa/tests/test_oauth.py
@@ -662,6 +662,22 @@ class TestJwtToken(unittest.TestCase):
                                  resulted in a call to /verify, but it did.")
 
     @responses.activate
+    def test_good_jwt_token_with_long_form_typ_header(self):
+        private_key = self.get_file_contents("private-key.json")
+        token = self._make_jwt({
+            "sub": "asdf",
+            "scope": "qwer",
+            "client_id": "foo"
+        }, private_key, header={
+            "typ": "application/at+JWT",
+        })
+        self.client.verify_token(token)
+        for c in responses.calls:
+            if c.request.url == 'https://server/v1/verify':
+                raise Exception("testing with a good token should not have \
+                                 resulted in a call to /verify, but it did.")
+
+    @responses.activate
     def test_wrong_key_jwt_token(self):
         self.verify_will_succeed = False
         bad_key = self.get_file_contents("bad-key.json")
@@ -677,6 +693,15 @@ class TestJwtToken(unittest.TestCase):
     def test_expired_jwt_token(self):
         private_key = self.get_file_contents("private-key.json")
         token = self._make_jwt({"qwer": "asdf", "exp": 0}, private_key)
+        with self.assertRaises(fxa.errors.TrustError):
+            self.client.verify_token(token)
+
+    @responses.activate
+    def test_jwt_token_with_wrong_typ(self):
+        private_key = self.get_file_contents("private-key.json")
+        token = self._make_jwt({"qwer": "asdf", "exp": 0}, private_key, header={
+          "typ": "rt+jwt"
+        })
         with self.assertRaises(fxa.errors.TrustError):
             self.client.verify_token(token)
 


### PR DESCRIPTION
Fixes #84. I also filed https://github.com/mozilla/fxa/pull/5888 to update the FxA docs in this regard.

@fzzzy r?