### PR TITLE
Support Key Stretching Version 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,6 @@ workflows:
   test:
     jobs:
       - python/test:
-          name: "Test on Python 2.7"
-          version: "2.7"
-          pkg-manager: pip-dist
-          args: "-r dev-requirements.txt"
-          pip-dependency-file: "dev-requirements.txt"
-          test-tool: pytest
-      - python/test:
           name: "Test on Python 3.8"
           version: "3.8"
           pkg-manager: pip-dist

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,23 @@
 ===========================================================
-PyFxA: Python library for interacting with Firefox Accounts
+PyFxA: Python library for interacting with Mozilla Accounts
 ===========================================================
 
 .. image:: https://travis-ci.org/mozilla/PyFxA.svg?branch=master
     :target: https://travis-ci.org/mozilla/PyFxA
 
-This is python library for interacting with the Firefox Accounts ecosystem.
+This is python library for interacting with the Mozilla Accounts (formerly known as the Firefox Accounts) ecosystem.
 
 Eventually, it is planned to provide easy support for the following features:
 
-* being a direct firefox accounts authentication client
+* being a direct mozilla accounts authentication client
 * being an FxA OAuth Service Provider
 * accessing attached services
-* helps interactions with Firefox Account servers wiht requests Authentication plugins.
+* helps interactions with Firefox Account servers with requests Authentication plugins.
 
 But none of that is ready yet; caveat emptor.
 
 
-Firefox Accounts
+Mozilla Accounts
 ================
 
 Currently, basic auth-server operations should work like so:
@@ -301,3 +301,25 @@ token request:
         (default to: https://api.accounts.firefox.com/v1)
       - FXA_OAUTH_SERVER_URL: To select the oauth server url
         (default to: https://oauth.accounts.firefox.com/v1)
+
+
+
+=====================
+Contributing to PyFxA
+=====================
+
+The basic requirements are:
+- Python 3.12.2 or higher
+- Pip 24.0
+
+To get start: 
+- `python -m pip install -r dev-requirements.txt`
+- `python setup.py install`
+- `python setup.py build`
+
+To run tests:
+- `pytest`
+
+
+
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,8 @@
 grequests
-mock;python_version<"3.3"
 responses
-pytest==4.6.4
-pytest-runner==4.5.1
+pytest
+pytest-runner
 pytest-cov
-pytest-flake8
 # Latest releases of pyotp do not support python2.
-pyotp==2.3.0
+pyotp
+parameterized

--- a/fxa/_utils.py
+++ b/fxa/_utils.py
@@ -428,3 +428,8 @@ def _encoded(value, encoding='utf-8'):
     if value_type != six.binary_type:
         return value.encode(encoding)
     return value
+
+
+def exactly_one_of(p1_val, p1_name, p2_val, p2_name):
+    if p1_val and p2_val or not p1_val and not p2_val:
+        raise ValueError(f"must specify exactly one of '{p1_name}' or '{p2_name}'")

--- a/fxa/constants.py
+++ b/fxa/constants.py
@@ -16,15 +16,7 @@ ENVIRONMENT_URLS = {
         "profile": "https://profile.stage.mozaws.net/v1",
         "token": "https://token.stage.mozaws.net/",
     },
-    "stable": {
-        "authentication": "https://stable.dev.lcip.org/auth/v1",
-        "oauth": "https://oauth-stable.dev.lcip.org/v1",
-        "content": "https://stable.dev.lcip.org/",
-        "profile": "https://stable.dev.lcip.org/profile/v1",
-        "token": None,
-    }
 }
 
 PRODUCTION_URLS = ENVIRONMENT_URLS['production']
 STAGE_URLS = ENVIRONMENT_URLS['stage']
-STABLE_URLS = ENVIRONMENT_URLS['stable']

--- a/fxa/tests/utils.py
+++ b/fxa/tests/utils.py
@@ -5,7 +5,6 @@ import time
 import random
 import requests
 import unittest # NOQA
-from binascii import unhexlify
 from six import binary_type
 from six.moves.urllib.parse import urlparse, urljoin
 
@@ -14,9 +13,8 @@ from fxa._utils import uniq
 
 DUMMY_EMAIL = "PyFxATester@restmail.net"
 DUMMY_PASSWORD = "l33tP@55W0rd"
-DUMMY_STRETCHED_PASSWORD = unhexlify(
-    "59eb52f6ee5ebe2b599161aaa9b171c3baa8bed594d4e2a8b4b539fb9eba8368"
-)
+DUMMY_SALT_CORE_V2 = '735e18bdc1e83d964930be1e89591263'
+DUMMY_SALT_V2 = f'identity.mozilla.com/picl/v1/quickStretchV2:{DUMMY_SALT_CORE_V2}'
 
 
 def mutate_one_byte(input):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -vv --cov=fxa --flake8
+addopts = -vv --cov=fxa


### PR DESCRIPTION
## Because:
Our APIs now support a new key stretching approach (ie key stretching V2)

## This Commit:
- Adds support for key stretching V2
  - The salt is now a random value and not the user's email
  - There are now 650000 iterations during the stretch instead of 1000.
- Test have been parameterized to run with both V1 and V2 key stretch approaches
- Effort has been taken to ensure that V1 approach still works
- Key stretch v1 is still the default mode. In order to activate V2, the client must be provided the `key_stretch_version=2` argument.

### Extra cleanup:
- Tests work again!
- Support for python 2 dropped
- Python 2 ci tests removed
- Adds doc about setup and running tests
- Updates references to Firefox Accounts to be Mozilla Accounts
- Unpins versions in dev-requirements, so libraries can update
- Updates 'stable' urls to point at staging. *.lcip.org are no longer valid
- Fixes bug in test tear down, so that an auth token is provided to `/account/destroy`
- Skips `test_resend_verify_code`, which was getting consistently rate limited.
- Skips tests with unsupported endpoints (e.g. `/certificate/sign` has been deprecated)

## Issue that this pull request solves
Closes: FXA-9008

## Checklist
- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x I have added necessary documentation (if appropriate).
