### PR TITLE
Fix formatting from "Contributing to PyFxA"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,13 +312,20 @@ The basic requirements are:
 - Python 3.12.2 or higher
 - Pip 24.0
 
-To get start: 
-- `python -m pip install -r dev-requirements.txt`
-- `python setup.py install`
-- `python setup.py build`
+To get started:
+
+.. code-block::
+
+    $ python -m pip install -r dev-requirements.txt
+    $ python setup.py install
+    $ python setup.py build
 
 To run tests:
-- `pytest`
+
+.. code-block::
+
+    $ pytest
+
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -309,6 +309,7 @@ Contributing to PyFxA
 =====================
 
 The basic requirements are:
+
 - Python 3.12.2 or higher
 - Pip 24.0
 


### PR DESCRIPTION
The section has been using markdown, but the file is in RST format. I have updated the section with the appropriate RST formatting. No content has been updated.

The section should renders as the following:
<img width="855" alt="Screenshot 2024-08-26 at 3 16 22 PM" src="https://github.com/user-attachments/assets/a6bc7f36-2511-4372-8ed7-b49a2017c18e">
