### PR TITLE
0.7.9 release 🙇🏼‍♀️ 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,12 @@ CHANGELOG
 
 This document describes changes between each past release.
 
+0.7.9 (2024-09-26)
+==================
+
+- Add ability to call APIs with the auth token required for the
+  new Mozilla Accounts server.
+
 0.7.8 (2024-03-14)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [ "hatchling" ]
 [project]
 name = "pyfxa"
 description = "Firefox Accounts client library for Python"
+version = "0.7.9"
 readme = "README.rst"
 keywords = [
   "accounts",


### PR DESCRIPTION
Could someone please do a new release of PyFxA? 

In particular, I would like to use the change included in this PR: https://github.com/mozilla/PyFxA/pull/104. Without this change, I could not call some REST API for account deletion required for my testing.

Please feel free to add more bullet points in `CHANGES.txt`.