### PR TITLE
feat: migrate to jwtoxide, uptick version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,10 +3,11 @@ CHANGELOG
 
 This document describes changes between each past release.
 
-0.8.2 (2025-12-11)
+0.9.0 (2025-12-11)
 ==================
 
 - Migrate to use jwtoxide
+- Remove Python 3.8 support
 
 0.8.1 (2025-05-01)
 ==================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,11 @@ CHANGELOG
 
 This document describes changes between each past release.
 
+0.8.2 (2025-12-11)
+==================
+
+- Migrate to use jwtoxide
+
 0.8.1 (2025-05-01)
 ==================
 

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -7,7 +7,7 @@ Python library for interacting with the Firefox Accounts ecosystem.
 
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __ver_tuple__ = tuple(__version__.split("."))
 
 

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -7,7 +7,7 @@ Python library for interacting with the Firefox Accounts ecosystem.
 
 """
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 __ver_tuple__ = tuple(__version__.split("."))
 
 

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -9,6 +9,7 @@ import hashlib
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 import jwt
+from jwtoxide import DecodingKey, Jwk, ValidationOptions, decode
 from fxa.cache import MemoryCache, DEFAULT_CACHE_EXPIRY
 from fxa.constants import PRODUCTION_URLS
 from fxa.errors import OutOfProtocolError, ScopeMismatchError, TrustError
@@ -204,9 +205,25 @@ class Client:
         # which tokens. So there's no value in checking it here, and in fact if
         # we check it here, it fails because the right audience isn't being
         # requested.
-        decoded = jwt.decode(
-            token, pubkey, algorithms=['RS256'], options={'verify_aud': False}
-        )
+        try:
+            # Try to first decode with jwtoxide
+            decoded = decode(
+                token,
+                DecodingKey.from_jwk(Jwk.from_json(key)),
+                ValidationOptions(
+                    aud=None,
+                    iss=None,
+                    required_spec_claims={"iat", "exp"},
+                    validate_aud=False,
+                    algorithms=["RS256"],
+                ),
+            )
+        except:
+            # If something goes wrong, fallback to PyJWT
+            pubkey = jwt.algorithms.RSAAlgorithm.from_jwk(key)
+            decoded = jwt.decode(
+                token, pubkey, algorithms=["RS256"], options={"verify_aud": False}
+            )
         # Ref https://tools.ietf.org/html/rfc7515#section-4.1.9 the `typ` header
         # is lowercase and has an implicit default `application/` prefix.
         typ = jwt.get_unverified_header(token).get('typ', '')

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -199,7 +199,6 @@ class Client:
         return resp['access_token']
 
     def _verify_jwt_token(self, key, token):
-        pubkey = jwt.algorithms.RSAAlgorithm.from_jwk(key)
         # The FxA OAuth ecosystem currently doesn't make good use of aud, and
         # instead relies on scope for restricting which services can accept
         # which tokens. So there's no value in checking it here, and in fact if

--- a/fxa/oauth.py
+++ b/fxa/oauth.py
@@ -218,7 +218,7 @@ class Client:
                     algorithms=["RS256"],
                 ),
             )
-        except:
+        except Exception:
             # If something goes wrong, fallback to PyJWT
             pubkey = jwt.algorithms.RSAAlgorithm.from_jwk(key)
             decoded = jwt.decode(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = [ "version" ]
 dependencies = [
   "cryptography",
   "hawkauthlib",
+  "jwtoxide",
   "pyjwt",
   "requests>=2.4.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,12 @@ license = "MPL-2.0"
 authors = [
   { name = "Mozilla Services", email = "services-dev@mozilla.org" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -72,7 +71,7 @@ cov = "pytest --cov-config=pyproject.toml --cov=fxa/ --cov-report term-missing {
 
 [[tool.hatch.envs.test.matrix]]
 # Note: When changing these, also update the .github/workflows/test.yml file.
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.flake8]
 max-line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = [ "version" ]
 dependencies = [
   "cryptography",
   "hawkauthlib",
-  "jwtoxide",
+  "jwtoxide==0.2.0",
   "pyjwt",
   "requests>=2.4.2",
 ]


### PR DESCRIPTION
## What's new
<img width="699" height="91" alt="Screenshot 2025-12-10 at 1 54 28 PM" src="https://github.com/user-attachments/assets/4175b8e1-1ee4-4910-8409-b1a457ec4f85" />




- Migrate pyjwt to jwtoxide in `_verify_jwt_token`. Jwtoxide boosts performance by almost 50%
- Uptick version to `0.8.2`, add to `changes.txt`