### PR TITLE
chore(version): Bump version to 0.8.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,12 @@ CHANGELOG
 
 This document describes changes between each past release.
 
+0.8.2 (2026-05-14)
+==================
+
+- Add CI WAF bypass header injection via ``CI_WAF_TOKEN`` env var
+- Skip live integration tests by default (opt-in via ``FXA_RUN_LIVE_TESTS=1``)
+
 0.8.1 (2025-05-01)
 ==================
 

--- a/fxa/__init__.py
+++ b/fxa/__init__.py
@@ -7,7 +7,7 @@ Python library for interacting with the Firefox Accounts ecosystem.
 
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __ver_tuple__ = tuple(__version__.split("."))
 
 


### PR DESCRIPTION
## Summary

- Bumps version to 0.8.2
- Adds changelog entry covering the WAF bypass header feature (#123) and the live-test skip default

## Test plan

- [ ] CI passes
- [ ] After merge, cut a `v0.8.2` GitHub release to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)